### PR TITLE
This is a simple fix to prevent highlight adding escape chars if its stdout is not connected to a tty

### DIFF
--- a/usr/local/bin/highlight
+++ b/usr/local/bin/highlight
@@ -1,3 +1,8 @@
 #!/bin/sh
+
+# Don't try to add coloring escape characters if they're not going to
+# be understood.
+tty -s || return
+
 sed "s/\($1\)/\x1b[31m\\1\x1b[39m/g"
 


### PR DESCRIPTION
Indeed we don't want those charaters in those examples:

 $ apt search gcc | less
 $ apt search gcc >out.txt

Signed-off-by: Franck Bui-Huu fbuihuu@gmail.com
