### PR TITLE
And if glib-compile-schemas is not there....

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -19,7 +19,9 @@ set -e
 case "$1" in
     configure)
 	update-rc.d mintsystem start 51 S .
-	glib-compile-schemas /usr/share/glib-2.0/schemas
+	if [ -e /usr/bin/glib-compile-schemas ]; then
+      glib-compile-schemas /usr/share/glib-2.0/schemas
+     fi
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)
 


### PR DESCRIPTION
KDE does not use it !
