### PR TITLE
prevent memory leak

### DIFF
--- a/usr/local/bin/search
+++ b/usr/local/bin/search
@@ -14,30 +14,36 @@ function usage
 directory=/
 case=i
 verbose=H
-while [ "$1" != "" ]; do
-    case $1 in
-        for | -f | --for )
+
+case "$1" in
+	for | -f | --for )
 		shift
-                text=$1
-                ;;
-        in | --in | -i )
-		shift
-		directory=$1
-                ;;
-        -h | --help )           
+		text="$1"
+		;;
+	-h | --help | * )
 		usage
-                exit
-                ;;
+		exit 1
+		;;
+esac
+
+case "$2" in
+	in | --in | -i )
+		shift
+		directory="$2"
+		;;
+	* )
+		usage
+		exit 1
+		;;
+esac
+
+case "$3" in
 	-c | --case-sensitive )
 		case=
 		;;
 	-s | --show-filenames-only )
 		verbose=l
 		;;
-        * )     
-		usage
-                exit 1
-    esac
-    shift
-done
+esac
+
 find $directory -type f -exec grep -$case$verbose "$text" --color=auto -n {} \; 


### PR DESCRIPTION
When specifying search with no parameters, it executes

find / -type f -exec grep -iH "" --color=auto -n {} \;

Which greps every file on the root partition (it bypasses the while loop), grinding the system to a halt. 

Specifying several case statements gives the expected behaviour (usage display) without affecting functionality.
