### PR TITLE
Don't require dbus in the init script

### DIFF
--- a/etc/init.d/mintsystem
+++ b/etc/init.d/mintsystem
@@ -2,7 +2,7 @@
 
 ### BEGIN INIT INFO
 # Provides:          mintsystem
-# Required-Start:    $local_fs $syslog $remote_fs dbus
+# Required-Start:    $local_fs $syslog $remote_fs
 # Required-Stop:     $local_fs $syslog $remote_fs
 # Default-Start:     S
 # Default-Stop:  


### PR DESCRIPTION
Fixes the ordering cycle issue (when systemd is the default init system), which is described [here](http://forums.linuxmint.com/viewtopic.php?f=198&t=132747&start=200#p894181).
