### PR TITLE
implement required options in init.d script

### DIFF
--- a/etc/init.d/mintsystem
+++ b/etc/init.d/mintsystem
@@ -8,5 +8,21 @@
 # Default-Stop:  
 ### END INIT INFO
 
-/usr/lib/linuxmint/mintSystem/mint-adjust.py
+. /lib/lsb/init-functions
 
+case $1 in
+    start|restart|force-reload)
+	/usr/lib/linuxmint/mintSystem/mint-adjust.py
+	;;
+    stop)
+	;;
+    status)
+	exit 0
+	;;
+    *)
+	echo "Usage: $0 {start|stop|status|restart|force-reload}" >&2
+	exit 3
+	;;
+esac
+
+exit 0


### PR DESCRIPTION
Fixes the following Lintian tags:
E: mintsystem: init.d-script-does-not-implement-required-option etc/init.d/mintsystem start
E: mintsystem: init.d-script-does-not-implement-required-option etc/init.d/mintsystem stop
E: mintsystem: init.d-script-does-not-implement-required-option etc/init.d/mintsystem restart
E: mintsystem: init.d-script-does-not-implement-required-option etc/init.d/mintsystem force-reload
W: mintsystem: init.d-script-does-not-source-init-functions etc/init.d/mintsystem