### PR TITLE
Added an add-repository command to apt script

### DIFF
--- a/usr/local/bin/apt
+++ b/usr/local/bin/apt
@@ -8,6 +8,7 @@ def usage():
 	print "       apt help command [options]"
 	print ""
 	print "Commands:"
+	print "add-repository	- Erase old downloaded archive files"
 	print "autoclean	- Erase old downloaded archive files"
 	print "autoremove	- Remove automatically all unused packages" 
 	print "build     	- Build binary or source packages from sources" 
@@ -106,6 +107,8 @@ elif argcommand == "deb":
 	command = sudo + " dpkg -i" + argoptions
 elif argcommand == "download":
     command = "LC_ALL=C apt-cache depends " + argoptions + " |grep -v \"Conflicts:\|Replaces:\"|awk '{print $NF}'|sed -e 's/[<>]//g'|xargs aptitude download -r"
+elif argcommand == "add-repository":
+	command = sudo + "add-apt-repository" + argoptions
 else:
 		usage()
 

--- a/usr/local/bin/apt
+++ b/usr/local/bin/apt
@@ -8,7 +8,7 @@ def usage():
 	print "       apt help command [options]"
 	print ""
 	print "Commands:"
-	print "add-repository	- Erase old downloaded archive files"
+	print "add-repository	- Add entries to apt sources.list"
 	print "autoclean	- Erase old downloaded archive files"
 	print "autoremove	- Remove automatically all unused packages" 
 	print "build     	- Build binary or source packages from sources" 


### PR DESCRIPTION
I really like this approach to simplifying the *apt* command more so than Debian has but the one thing that I felt that was missing was integration with the add-apt-repository script to add new entries to the sources.list file. This pull requests adds an add-repository command to the apt script.