### PR TITLE
Added list command to access more of the features of /usr/bin/apt

### DIFF
--- a/usr/local/bin/apt
+++ b/usr/local/bin/apt
@@ -27,6 +27,7 @@ def usage():
 	print "help     	- Show help for a command"
 	print "hold		- Hold a package"
 	print "install   	- Install/upgrade packages"
+	print "list		- List currently installed ( --installed ) or upgradable ( --upgradable ) packages" 
 	print "policy   	- Show policy settings" 
 	print "purge    	- Remove packages and their configuration files" 
 	print "recommends	- List missing recommended packages for a particular package"
@@ -109,6 +110,8 @@ elif argcommand == "download":
     command = "LC_ALL=C apt-cache depends " + argoptions + " |grep -v \"Conflicts:\|Replaces:\"|awk '{print $NF}'|sed -e 's/[<>]//g'|xargs aptitude download -r"
 elif argcommand == "add-repository":
 	command = sudo + " add-apt-repository" + argoptions
+elif argcommand == "list":
+        command = "/usr/bin/apt list" + argoptions
 else:
 		usage()
 


### PR DESCRIPTION
After reviewing the article on APT posted at http://www.howtogeek.com/234583/simplify-command-line-package-management-with-apt-instead-of-apt-get/ I noticed that some of the features of the native /usr/bin/apt were missing in the python version which gets run by default. This patch is to access the native apt command to make use of the list command.