### PR TITLE
Create pasteclip

### DIFF
--- a/usr/local/bin/pasteclip
+++ b/usr/local/bin/pasteclip
@@ -1,0 +1,26 @@
+#!/usr/bin/python3
+
+import sys
+import os
+import stat
+import subprocess
+
+content = ""
+
+mode = os.fstat(0).st_mode
+if stat.S_ISFIFO(mode):
+    content = sys.stdin.read()
+elif stat.S_ISREG(mode):
+    content = sys.stdin.read()
+else:
+    args = sys.argv[1:]
+    if len(args) == 1 and os.path.exists(args[0]):
+        with open(args[0], 'r') as infile:
+            content = infile.read()
+    else:
+        str_args = ' '.join(args)
+        content = str_args
+
+#if content != "":
+    p = subprocess.Popen(["/usr/bin/gist-paste","-P"], stdin=subprocess.PIPE)
+    p.communicate(content.encode("UTF-8"))


### PR DESCRIPTION
the command ultimately executes 'gist-paste -P' which sends a hilited txt selection to gist, will require 'xclip' to already be installed.

xclip is avail for use in LMDE/LMDE2/LM17.x/LM18

xclip is avail on debian https://packages.debian.org/search?keywords=xclip and 
ubuntu http://packages.ubuntu.com/search?keywords=xclip 