### PR TITLE
Use Mimetypes instead of Extensions

### DIFF
--- a/usr/share/nemo/actions/mint-sha256sum.nemo_action
+++ b/usr/share/nemo/actions/mint-sha256sum.nemo_action
@@ -1,8 +1,10 @@
 [Nemo Action]
 Active=true
 Name=Check SHA256
+Name[de]=Prüfe SHA256-Hash
 Name[fr]=Vérifier le SHA256
 Comment=Check the SHA256 signature of the file
+Comment[de]=Prüfe den SHA256-Hash der Datei
 Comment[fr]=Vérifier la signature SHA256 de ce fichier
 Exec=mint-sha256sum '%F'
 Icon-Name=gtk-execute

--- a/usr/share/nemo/actions/mint-sha256sum.nemo_action
+++ b/usr/share/nemo/actions/mint-sha256sum.nemo_action
@@ -7,4 +7,4 @@ Comment[fr]=Vérifier la signature SHA256 de ce fichier
 Exec=mint-sha256sum '%F'
 Icon-Name=gtk-execute
 Selection=S
-Extensions=iso;img;
+Mimetypes=application/x-iso9660-image;

--- a/usr/share/nemo/actions/mint-sha256sum.nemo_action
+++ b/usr/share/nemo/actions/mint-sha256sum.nemo_action
@@ -1,8 +1,8 @@
 [Nemo Action]
 Active=true
 Name=Check SHA256
-Comment=Check the SHA256 signature of the file
 Name[fr]=Vérifier le SHA256
+Comment=Check the SHA256 signature of the file
 Comment[fr]=Vérifier la signature SHA256 de ce fichier
 Exec=mint-sha256sum '%F'
 Icon-Name=gtk-execute


### PR DESCRIPTION
Fixes issue #63 by changing the condition from `Extensions` to `Mimetypes`.

Also adds German translation and reorders the translations to be directly under the default name.