### PR TITLE
Add progress dialog and title

### DIFF
--- a/usr/local/bin/mint-sha256sum
+++ b/usr/local/bin/mint-sha256sum
@@ -1,2 +1,7 @@
 #!/bin/sh
-(HASH=$(sha256sum "$1"); exec 1>&-; zenity --title="mint-sha256sum" --info --text="$HASH" --no-wrap) | zenity --progress  --title="mint-sha256sum" --pulsate --auto-close --no-cancel
+(
+    HASH=$(sha256sum "$1")
+    # send EOF to end the zenity progress dialog
+    exec 1>&-
+    zenity --title="mint-sha256sum" --info --text="$HASH" --no-wrap
+) | zenity --progress  --title="mint-sha256sum" --pulsate --auto-close --no-cancel

--- a/usr/local/bin/mint-sha256sum
+++ b/usr/local/bin/mint-sha256sum
@@ -1,2 +1,2 @@
 #!/bin/sh
-zenity --info --text=`sha256sum "$1"` --no-wrap
+(HASH=$(sha256sum "$1"); exec 1>&-; zenity --title="mint-sha256sum" --info --text="$HASH" --no-wrap) | zenity --progress  --title="mint-sha256sum" --pulsate --auto-close --no-cancel


### PR DESCRIPTION
Fixes issue https://github.com/linuxmint/nemo/issues/1265 by adding a pulsating `zenity` progress dialog.

The cancel button in the progress dialog is not shown because it doesn't stop the `sha256sum` process. `sha256sum` doesn't print to standard out and the pipe is only closed on the next output after hitting the cancel button. I also tried the `--auto-kill` option of `zenity` but this also doesn't stop the `sha256sum` process. Maybe someone else has an idea for this?

Putting the info dialog into the subshell is needed because there is otherwise no way to get the hash, the zenity progress dialog eats all the output like a black hole ;)

Also changes the title of the dialogs to `mint-sha256sum`.