### PR TITLE
Fix "apt recommends" catching e.g. "apt d"

### DIFF
--- a/usr/local/bin/apt
+++ b/usr/local/bin/apt
@@ -92,7 +92,7 @@ elif argcommand in ("changelog", "reinstall"):
 elif argcommand in ("stats", "depends", "rdepends", "policy"):
     # apt-cache
     command = "apt-cache %s %s" % (argcommand, argoptions)
-elif argcommand in ("recommends"):
+elif argcommand in ("recommends", ):
     command = "/usr/lib/linuxmint/mintsystem/mint-apt-recommends.py " + argoptions
 elif argcommand in ("showhold", "hold", "unhold"):
     # apt-mark


### PR DESCRIPTION
The following expression is a string, not a tuple:

    ("recommends")

So running `apt d`, or `apt e`, or `apt (any substring of the word 'recommends')` is equivalent to running `apt recommends`.