### PR TITLE
Fix for apt failing when not run from a terminal.

### DIFF
--- a/usr/local/bin/apt
+++ b/usr/local/bin/apt
@@ -68,7 +68,10 @@ show_help = False
 sort = False
 highlight = False
 
-rows, columns = os.popen('stty size', 'r').read().split()
+if sys.stdin.isatty():
+	rows, columns = os.popen('stty size', 'r').read().split()
+else:
+	rows, columns = 24, 80
 
 if argcommand == "help":
     if len(sys.argv) < 3:


### PR DESCRIPTION
Fixes issue #69 by adding a check that the script is actually running in a terminal before checking for the terminal dimensions.