### PR TITLE
apt: update/upgrade reloads running mintupdate

### DIFF
--- a/usr/local/bin/apt
+++ b/usr/local/bin/apt
@@ -154,4 +154,11 @@ else:
         ps2.wait()
     else:
         return_code = subprocess.call(command)
+        # automatically reload a running mintupdate after an update or upgrade
+        if argcommand in ("update", "upgrade", "full-upgrade"):
+            import psutil
+            for p in psutil.process_iter(attrs=["name"]):
+                if p.info["name"] == "mintUpdate":
+                    subprocess.call("mintupdate-launcher")
+                    break
         sys.exit(return_code)


### PR DESCRIPTION
This is a quick and dirty fix for the problem of an apt update or upgrade leaving a running mintupdate in an inconsistent state.

This pull request is more about highlighting the issue, I'm not convinced this should actually be merged. I mean it can be, it works perfectly fine, but the argument against it is that those two apt commands are not the only way to work with the package management system. Ideally mintupdate itself would monitor both apt's cache and its configuration (mainly preferences/pins) and refresh its state accordingly (without triggering a full apt update, of course).