### PR TITLE
apt-preference: Cosmetic

### DIFF
--- a/etc/apt/preferences.d/official-extra-repositories.pref
+++ b/etc/apt/preferences.d/official-extra-repositories.pref
@@ -1,3 +1,3 @@
 Package: *
-Pin: origin build.linuxmint.com
+Pin: origin "build.linuxmint.com"
 Pin-Priority: 700


### PR DESCRIPTION
According to man apt_preferences origin argument is double-quoted.
This change has no effect but aims to improve readability.