### PR TITLE
apt: fix bash completion handling of -- arguments

### DIFF
--- a/etc/bash_completion.d/apt-linux-mint
+++ b/etc/bash_completion.d/apt-linux-mint
@@ -11,12 +11,13 @@ _apt()
 
     # Completion of commands.
     if [[ $COMP_CWORD == 1 ]]; then
-    COMPREPLY=( $(compgen -W '\
-        add-repository autoclean autoremove build build-dep changelog check clean \
-        contains content deb depends dist-upgrade download \
-        dselect-upgrade edit-sources full-upgrade held help hold install list policy purge recommends rdepends \
-        reinstall remove search show showhold source sources unhold update \
-        upgrade version' "$cur" ) )
+    COMPREPLY=( $(compgen -W '
+        add-repository autoclean autoremove build build-dep changelog check clean
+        contains content deb depends dist-upgrade download
+        dselect-upgrade edit-sources full-upgrade held help hold install list policy purge recommends rdepends
+        reinstall remove search show showhold source sources unhold update
+        upgrade version --help
+        ' -- "$cur" ) )
     return 0
     fi
 


### PR DESCRIPTION
Previously, if you typed "apt --f" and press tab, you'll get some errors like:

apt --fbash: compgen: --: invalid option
compgen: usage: compgen [-abcdefgjksuv] [-o option]  [-A action] [-G globpat] [-W wordlist]  [-F function] [-C command] [-X filterpat] [-P prefix] [-S suffix] [word]
bash: compgen: --: invalid option

This is because of a missing "--" separator in the call to compgen, as well as inappropriate usage of backslashes.

This also adds completion for the --help flag, i.e.;

apt --h[TAB]
completes as:
apt --help