### PR TITLE
Make apt work with apt patterns

### DIFF
--- a/usr/local/bin/apt
+++ b/usr/local/bin/apt
@@ -62,7 +62,7 @@ if len(sys.argv) < 2:
     usage()
 
 argcommand = sys.argv[1]
-argoptions = " ".join(sys.argv[2:])
+argoptions = sys.argv[2:]
 
 command = ""
 
@@ -71,73 +71,74 @@ sort = False
 highlight = False
 
 if sys.stdin.isatty():
-	rows, columns = os.popen('stty size', 'r').read().split()
+    rows, columns = os.popen('stty size', 'r').read().split()
 else:
-	rows, columns = 24, 80
+    rows, columns = 24, 80
 
 if argcommand == "help":
     if len(sys.argv) < 3:
         usage()
     show_help = True
     argcommand = sys.argv[2]
-    argoptions = " ".join(sys.argv[3:])
+    argoptions = sys.argv[3:]
 
 if argcommand in aliases.keys():
     argcommand = aliases[argcommand]
 
 if argcommand in ("autoremove", "list", "show", "install", "remove", "purge", "update", "upgrade", "full-upgrade", "edit-sources", "showsrc"):
     # apt
-    command = "/usr/bin/apt %s %s" % (argcommand, argoptions)
+    command = ["/usr/bin/apt", argcommand] + argoptions
 elif argcommand in ("clean", "dselect-upgrade", "build-dep", "check", "autoclean", "source", "moo"):
     # apt-get
-    command = "apt-get %s %s" % (argcommand, argoptions)
+    command = ["apt-get", argcommand] + argoptions
 elif argcommand in ("reinstall", ):
     # aptitude
-    command = "aptitude %s %s" % (argcommand, argoptions)
+    command = ["aptitude", argcommand] + argoptions
 elif argcommand in ("stats", "depends", "rdepends", "policy"):
     # apt-cache
-    command = "apt-cache %s %s" % (argcommand, argoptions)
+    command = ["apt-cache", argcommand] + argoptions
 elif argcommand in ("changelog", ):
-    command = "/usr/lib/python3/dist-packages/mintcommon/apt_changelog.py " + argoptions
+    command = ["/usr/lib/python3/dist-packages/mintcommon/apt_changelog.py"] + argoptions
 elif argcommand in ("recommends", ):
-    command = "/usr/lib/linuxmint/mintsystem/mint-apt-recommends.py " + argoptions
+    command = ["/usr/lib/linuxmint/mintsystem/mint-apt-recommends.py"] + argoptions
 elif argcommand in ("showhold", "hold", "unhold"):
     # apt-mark
-    command = "apt-mark %s %s" % (argcommand, argoptions)
+    command = ["apt-mark", argcommand] + argoptions
 elif argcommand in ("markauto", "markmanual"):
     # apt-mark
-    command = "apt-mark %s %s" % (argcommand[4:], argoptions)
+    command = ["apt-mark", argcommand[4:]] + argoptions
 elif argcommand == "contains":
-    command = "dpkg -S %s" % argoptions
+    command = ["dpkg", "-S"] + argoptions
 elif argcommand == "content":
-    command = "dpkg -L %s" % argoptions
+    command = ["dpkg", "-L"] + argoptions
 elif argcommand == "deb":
-    command = "dpkg -i %s" % argoptions
+    command = ["dpkg", "-i"] + argoptions
 elif argcommand == "build":
-    command = "dpkg-buildpackage %s" % argoptions
+    command = ["dpkg-buildpackage"] + argoptions
 elif argcommand == "version":
+    command = ["dpkg-buildpackage"] + argoptions
     try:
-        version = subprocess.check_output("dpkg-query -f '${Version}' -W %s 2>/dev/null" % shlex.quote(argoptions), shell=True).decode("UTF-8")
+        version = subprocess.check_output("dpkg-query -f '${Version}' -W %s 2>/dev/null" % shlex.quote(" ".join(argoptions)), shell=True).decode("UTF-8")
         print (version)
     except:
         print ("")
     sys.exit(0)
 elif argcommand == "download":
-    command = "/usr/lib/linuxmint/mintsystem/mint-apt-download.py " + argoptions
+    command = ["/usr/lib/linuxmint/mintsystem/mint-apt-download.py"] + argoptions
 elif argcommand == "add-repository":
-    command = "add-apt-repository %s" % argoptions
+    command = ["add-apt-repository"] + argoptions
 elif argcommand == "search":
-    command = "aptitude -w %s %s %s" % (columns, argcommand, argoptions)
+    command = ["aptitude", "-w", columns, argcommand] + argoptions
 else:
     usage()
     sys.exit(1)
 
 # Sudo prefix
 if os.getuid() != 0 and argcommand in ("autoremove", "install", "remove", "purge", "update", "upgrade", "full-upgrade", "edit-sources", "clean", "dselect-upgrade", "build-dep", "check", "autoclean", "reinstall", "deb", "hold", "unhold", "add-repository", "markauto", "markmanual"):
-    command = "sudo %s" % command
+    command = ["sudo"] + command
 
 # Color highlighting
-if argcommand in ("content", "version", "policy", "depends", "rdepends", "search") and len(argoptions.strip()) > 1:
+if argcommand in ("content", "version", "policy", "depends", "rdepends", "search") and len(argoptions) >= 1:
     highlight = True
 
 # Sorting
@@ -145,22 +146,24 @@ if argcommand in ("content", "contains"):
     sort = True
 
 if show_help:
-    print("\"apt " + argcommand + " " + argoptions + "\" is equivalent to \"" + command + "\"")
+    print("\"apt " + argcommand + " " + " ".join(argoptions) + "\" is equivalent to \"" + " ".join(command) + "\"")
 else:
-    command = command.split()
-    if sort and highlight:
-        ps1 = subprocess.Popen(command, stdout=subprocess.PIPE)
-        ps2 = subprocess.Popen(('sort'), stdin=ps1.stdout, stdout=subprocess.PIPE)
-        ps3 = subprocess.Popen(('highlight-mint', argoptions), stdin=ps2.stdout)
-        ps3.wait()
-    elif sort:
-        ps1 = subprocess.Popen(command, stdout=subprocess.PIPE)
-        ps2 = subprocess.Popen(('sort'), stdin=ps1.stdout)
-        ps2.wait()
-    elif highlight:
-        ps1 = subprocess.Popen(command, stdout=subprocess.PIPE)
-        ps2 = subprocess.Popen(('highlight-mint', argoptions), stdin=ps1.stdout)
-        ps2.wait()
-    else:
-        return_code = subprocess.call(command)
-        sys.exit(return_code)
+    try:
+        if sort and highlight:
+            ps1 = subprocess.Popen(command, stdout=subprocess.PIPE)
+            ps2 = subprocess.Popen("sort", stdin=ps1.stdout, stdout=subprocess.PIPE)
+            ps3 = subprocess.Popen(["highlight-mint"] + argoptions, stdin=ps2.stdout)
+            ps3.wait()
+        elif sort:
+            ps1 = subprocess.Popen(command, stdout=subprocess.PIPE)
+            ps2 = subprocess.Popen("sort", stdin=ps1.stdout)
+            ps2.wait()
+        elif highlight:
+            ps1 = subprocess.Popen(command, stdout=subprocess.PIPE)
+            ps2 = subprocess.Popen(["highlight-mint"] + argoptions, stdin=ps1.stdout)
+            ps2.wait()
+        else:
+            return_code = subprocess.call(command)
+            sys.exit(return_code)
+    except KeyboardInterrupt:
+        print()


### PR DESCRIPTION
From Linux Mint 20 `/usr/bin/apt` uses [apt patterns](https://manpages.ubuntu.com/manpages/focal/man7/apt-patterns.7.html) instead of wildcards. Our apt doesn't work correctly with this as it didn't keep arguments containing whitespace as one argument. For example `apt list '~n^gedit ~ri386'` (find all gedit*:i386 packages) would not return the same list as `/usr/bin/apt list '~n^gedit ~ri386'`. This fixes that by changing variables command and argoptions from strings to lists.