### PR TITLE
Fix a crash when using apt search in non-tty enviroments

### DIFF
--- a/usr/local/bin/apt
+++ b/usr/local/bin/apt
@@ -82,7 +82,7 @@ highlight = False
 if sys.stdin.isatty():
     rows, columns = os.popen('stty size', 'r').read().split()
 else:
-    rows, columns = 24, 80
+    rows, columns = '24', '80'
 
 if argcommand == "help":
     if len(sys.argv) < 3:


### PR DESCRIPTION
The columns variable is used in line 143 as a command argument.
However when using an int as a command argument you will get a crash with the following Traceback:
```
Traceback (most recent call last):
  File "/usr/local/bin/apt", line 173, in <module>
    ps1 = subprocess.Popen(command, stdout=subprocess.PIPE)
  File "/usr/lib/python3.8/subprocess.py", line 858, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.8/subprocess.py", line 1639, in _execute_child
    self.pid = _posixsubprocess.fork_exec(
TypeError: expected str, bytes or os.PathLike object, not int
```
Since line 83 sets rows and columns to values of type string, this pr changes line 85 to also set them to type string to avoid confusion in the future.

This error can happen for example when using `deborphan -a --no-show-section | xargs apt search`.
A minimal example is `echo h | apt search hello`.