### PR TITLE
Fix Steam not receiving params

### DIFF
--- a/usr/share/linuxmint/adjustments/15-mintsystem.menu
+++ b/usr/share/linuxmint/adjustments/15-mintsystem.menu
@@ -1,1 +1,1 @@
-exec /usr/share/applications/steam.desktop sh -c 'STEAM_FRAME_FORCE_CLOSE=1 steam' %U
+exec /usr/share/applications/steam.desktop sh -c 'STEAM_FRAME_FORCE_CLOSE=1 steam %U'


### PR DESCRIPTION
As mentioned in https://github.com/ValveSoftware/steam-for-linux/issues/7076#issuecomment-991980167 Steam is unable to receive params resulting in breakage of the [Steam browser protocol](https://developer.valvesoftware.com/wiki/Steam_browser_protocol).

Putting `%U` inside the quotation marks makes it work again.