### PR TITLE
Fixed command line options parsing

### DIFF
--- a/usr/local/bin/apt
+++ b/usr/local/bin/apt
@@ -75,11 +75,12 @@ argoptions = sys.argv[2:]
 
 for command in ["install", "remove", "update", "clean"]:
     if argcommand.startswith("-") and command in argoptions:
-            for i in range(0, len(argoptions)):
-                if argoptions[i] == command:
-                    argoptions[i] = argcommand
-                    argcommand = command
-                    break
+        while argcommand != command:
+            temp = argoptions[0]
+            for i in range(1, len(argoptions)):
+                argoptions[i-1] = argoptions[i]
+            argoptions[len(argoptions)-1] = argcommand
+            argcommand = temp
 
 command = ""
 


### PR DESCRIPTION
On LMDE6, I have backports configured. I noticed that `apt -t bookworm-backports install qemu` fails with a strange looking error:

```
root@lmde:~# apt -t bookworm-backports install qemu
Reading package lists... Done
E: The value 'qemu' is invalid for APT::Default-Release as such a release is not available in the sources
```

This boils down to how `/usr/local/bin/apt` is parsing command line options. In above example, that Python code makes a good effort in switching the `-t` with `install` but that leaves the system with `apt install bookworm-backports -t qemu` which ofc produces the same error. This PR implements a simple rotation that will keep putting options on the back of the arguments until finished.

Needless to say that `apt install qemu -t bookworm-backports` works already without this modification.

I did notice this:

```
root@lmde:~# /usr/local/bin/apt help install
"apt install " is equivalent to "/usr/bin/apt install"
```

So it could be by design. But in that case, just throw an error if the first argument is not a valid command?
