### PR TITLE
Update dns-fix

### DIFF
--- a/usr/bin/dns-fix
+++ b/usr/bin/dns-fix
@@ -1,2 +1,15 @@
 #!/bin/bash
-sudo cp /usr/share/linuxmint/mintsystem/templates/resolv.conf /etc/resolv.conf
+echo 
+echo 
+echo "DNS FIXING SCRIPT"
+echo "This script will copy over your existing /etc/resolv.conf with a new file."
+echo "This may fix issues with DNS if your system is connected to the internet, but not able to resolve websites"
+echo "This will require sudo access."
+echo
+echo 
+read -r -p "Do you wish to continue? [y/N] " -n 1
+echo 
+case "$REPLY" in 
+	y|Y ) echo "Copying /usr/share/linuxmint/mintsystem/templates/resolv.conf to /etc/resolv.conf" && sudo cp /usr/share/linuxmint/mintsystem/templates/resolv.conf /etc/resolv.conf;;
+	* ) echo "OK, exiting.";;
+esac


### PR DESCRIPTION
made it more obvious what dns-fix does and added an option to bail out; useful for people who are looking for other commands that start with "dns" and think, "oh, what does dns-fix do?"

I was working on DNS on my router and it wasn't functioning correctly, I spent about 30 minutes fiddling on my router before I noticed that the computer was using 8.8.8.8 for dns instead of my local dns provider. I had run "dns-fix --help" and that was the culprit, so this is just an update to the script to prevent changes from being made accidentally. 