### PR TITLE
Update resolv.conf

### DIFF
--- a/usr/share/linuxmint/mintsystem/templates/resolv.conf
+++ b/usr/share/linuxmint/mintsystem/templates/resolv.conf
@@ -1,4 +1,4 @@
 # This file was written by dns-fix (mintsystem)
 
-# Google DNS
-nameserver 8.8.8.8
+# Quad9 DNS
+nameserver 9.9.9.9


### PR DESCRIPTION
quad 9 is better than google dns if you're paranoid, as many linux mint users are.